### PR TITLE
Only close when strategy is enabled

### DIFF
--- a/weighted_strategy.pine
+++ b/weighted_strategy.pine
@@ -536,9 +536,9 @@ if time >= start and time <= end
     // * Set Exits
     // ***************************************************************************************************************************************************************************
     if allow_longs == true and allow_shorts == false
-        strategy.close('Long', when=close_long1 or close_long5, qty_percent=100, comment='LONG', alert_message=alarm_label_close_long)
+        strategy.close('Long', when=(str_1 and close_long1) or (str_5 and close_long5), qty_percent=100, comment='LONG', alert_message=alarm_label_close_long)
     if allow_longs == false and allow_shorts == true
-        strategy.close('Short', when=close_short1 or close_short5, qty_percent=100, comment='SHORT', alert_message=alarm_label_close_short)
+        strategy.close('Short', when=(str_1 and close_short1) or (str_5 and close_short5), qty_percent=100, comment='SHORT', alert_message=alarm_label_close_short)
     if allow_shorts == true and strategy.position_size < 0 and stoploss and since_entry > 0
         strategy.close('Short', when=stop_source >= price_stop_short, qty_percent=100, comment='STOP', alert_message=alarm_label_SL)
         if str_6


### PR DESCRIPTION
I was trying to configure the strategy with only `long` enabled. However, strategy 5 always closed instantly (although not enabled).

This change is probably not sufficient, since it does not respect if the weighted strategy is enabled or not.
Please let me know your opinion on this.